### PR TITLE
Removed unmatched ctx.save();

### DIFF
--- a/fabric.curvedText.js
+++ b/fabric.curvedText.js
@@ -361,7 +361,7 @@
 			if(!this.letters)
 				return;
 
-			ctx.save();
+			//ctx.save();
 			this.transform(ctx);
 
 			var groupScaleFactor=Math.max(this.scaleX, this.scaleY);


### PR DESCRIPTION
This was causing problems with the canvas's `setZoom()` function.
