### PR TITLE
Fix multiple object moving togheter with the curved text

### DIFF
--- a/fabric.curvedText.js
+++ b/fabric.curvedText.js
@@ -433,7 +433,7 @@
 			if(!this.letters)
 				return;
 
-			//ctx.save();
+			ctx.save();
 			this.transform(ctx);
 
 			var groupScaleFactor=Math.max(this.scaleX, this.scaleY);
@@ -465,7 +465,7 @@
 //				this.drawBorders(ctx);
 //				this.drawControls(ctx);
 //			}
-//			ctx.restore();
+			ctx.restore();
 			this.setCoords();
 		},
 		/**


### PR DESCRIPTION
Saving and restoring context is necessary before a this.Transform(ctx) operation in fabricjs rendering queque.

closes #29

Cheers, Andrea.