### PR TITLE
Curved Text Character Angle

### DIFF
--- a/fabric.curvedText.js
+++ b/fabric.curvedText.js
@@ -218,12 +218,11 @@
 
 					if(this.effect==='curved'){
 						thisLetterAngle=((this.letters.item(i).width+space)/this.radius)/(Math.PI/180);
-						curAngleRotation=multiplier*((multiplier*curAngle)+lastLetterAngle+(thisLetterAngle/4));	//4 is better than 2 for some reason
 						curAngle=multiplier*((multiplier*curAngle)+lastLetterAngle);
 						angleRadians=curAngle*(Math.PI/180);
 						lastLetterAngle=thisLetterAngle;
 
-						this.letters.item(i).setAngle(curAngleRotation);
+						this.letters.item(i).setAngle(curAngle);
 						this.letters.item(i).set('top', multiplier*-1*(Math.cos(angleRadians)*this.radius));
 						this.letters.item(i).set('left', multiplier*(Math.sin(angleRadians)*this.radius));
 						this.letters.item(i).set('padding', 0);


### PR DESCRIPTION
I have make changes which will solve unknown reason of divide by 4 (it must be 2).
You must set 'curAngle' value as angle of character instead of 'curAngleRotation'. So you don't need to set curAngleRotation.
To test and see difference of this change, set radius to '200' and spacing to '575' with both files.

[Here](https://jsfiddle.net/akkivaghasiya5/uwnd4dz6/2/) you can see difference. Upper horizontal two characterized string is using CurvedText(unchanged). Lower horizontal two characterized string is using chabed CurvedText.